### PR TITLE
Replaced '<' with &lt; for javadoc generation

### DIFF
--- a/src/main/java/com/simsilica/ethereal/net/SentState.java
+++ b/src/main/java/com/simsilica/ethereal/net/SentState.java
@@ -69,7 +69,7 @@ public class SentState {
 
     /**
      *  Returns true if this state is before the specified messageId.  Message IDs
-     *  wrap so a simple < check is not enough.
+     *  wrap so a simple &lt; check is not enough.
      */
     public boolean isBefore( int compare ) {
         if( Math.abs(messageId - compare) > 32000 ) {


### PR DESCRIPTION
Fix invalid formatting error for javadoc generation
